### PR TITLE
Disable recieve btn as default

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,6 +4,9 @@ var affirmationRadio = document.querySelector('.affirmation-container');
 var mantraRadio = document.querySelector('.mantra-container');
 var resultsContainer = document.querySelector('.results-container');
 
+// Disable the "Receive Message" button by default
+receiveMessageBtn.disabled = true;
+
 //Event Listeners
 receiveMessageBtn.addEventListener('click', displayRandomMessage);
 


### PR DESCRIPTION
Completed first bullet of Error handling and clear button CYOA. Added default functionality to not allow the "Receive Message" button to be hit if a radio button is not chosen.